### PR TITLE
[Fix #17] Don't add non-title entries to imenu

### DIFF
--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -2405,7 +2405,8 @@ Returns nil if there was no xref found."
 (defun adoc-title-descriptor (&optional strict-match )
   "Returns title descriptor of title point is in.
 
-When STRICT-MATCH is t, 2 line title length must be within 2 chars of undertext
+When STRICT-MATCH is t, and 2 line title is used, the lengths of the underline
+text and title must not differ by more than 2 characters.
 
 Title descriptor looks like this: (TYPE SUB-TYPE LEVEL TEXT START END)
 
@@ -2442,8 +2443,11 @@ trailing delimiter ('== my title ==').
                      (forward-line -1)
                      (beginning-of-line)
                      (looking-at (adoc-re-two-line-title (nth level adoc-two-line-title-del)))))
-               ;; avoid matching non-title elements
-               (or (not strict-match) (<= (abs (- (length (match-string 3)) (length (match-string 2)))) 2))
+               ;; If strict-mode, expect title and underline text lengths to be at most +-2 characters different
+               (or (not strict-match)
+                   (<= (abs (- (length (match-string 3))
+                               (length (match-string 2))))
+                       2))
                (not (string-prefix-p "[" (match-string 2))))
           (setq type 2)
           (setq text (match-string 2))

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -2435,11 +2435,14 @@ trailing delimiter ('== my title ==').
          ;; method ensuring the correct length of the underline, be aware that
          ;; due to adoc-adjust-title-del we sometimes want to find a title which has
          ;; the wrong underline length.
-         ((or (looking-at (adoc-re-two-line-title (nth level adoc-two-line-title-del)))
-              (save-excursion
-                (forward-line -1)
-                (beginning-of-line)
-                (looking-at (adoc-re-two-line-title (nth level adoc-two-line-title-del)))))
+         ((and (or (looking-at (adoc-re-two-line-title (nth level adoc-two-line-title-del)))
+                   (save-excursion
+                     (forward-line -1)
+                     (beginning-of-line)
+                     (looking-at (adoc-re-two-line-title (nth level adoc-two-line-title-del)))))
+               ;; avoid matching non-title elements
+               (eql (length (match-string 3)) (length (match-string 2)))
+               (not (string-prefix-p "[" (match-string 2))))
           (setq type 2)
           (setq text (match-string 2))
           (setq found t))
@@ -2653,9 +2656,10 @@ LOCAL-ATTRIBUTE-FACE-ALIST before it is looked up in
         (let* ((descriptor (adoc-title-descriptor))
                (title-text (nth 3 descriptor))
                (title-pos (nth 4 descriptor)))
-          (setq
-           index-alist
-           (cons (cons title-text title-pos) index-alist)))))
+          (unless (null title-text)
+            (setq
+             index-alist
+             (cons (cons title-text title-pos) index-alist))))))
     (nreverse index-alist)))
 
 (defvar adoc-mode-syntax-table

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -2402,8 +2402,10 @@ Returns nil if there was no xref found."
                       (> saved-point (match-end 0)))))
       id)))
 
-(defun adoc-title-descriptor()
+(defun adoc-title-descriptor (&optional strict-match )
   "Returns title descriptor of title point is in.
+
+When STRICT-MATCH is t, 2 line title length must be within 2 chars of undertext
 
 Title descriptor looks like this: (TYPE SUB-TYPE LEVEL TEXT START END)
 
@@ -2441,7 +2443,7 @@ trailing delimiter ('== my title ==').
                      (beginning-of-line)
                      (looking-at (adoc-re-two-line-title (nth level adoc-two-line-title-del)))))
                ;; avoid matching non-title elements
-               (eql (length (match-string 3)) (length (match-string 2)))
+               (or (not strict-match) (<= (abs (- (length (match-string 3)) (length (match-string 2)))) 2))
                (not (string-prefix-p "[" (match-string 2))))
           (setq type 2)
           (setq text (match-string 2))
@@ -2653,7 +2655,7 @@ LOCAL-ATTRIBUTE-FACE-ALIST before it is looked up in
       (goto-char 0)
       (while (re-search-forward re-all-titles nil t)
         (backward-char) ; skip backwards the trailing \n of a title
-        (let* ((descriptor (adoc-title-descriptor))
+        (let* ((descriptor (adoc-title-descriptor t))
                (title-text (nth 3 descriptor))
                (title-pos (nth 4 descriptor)))
           (unless (null title-text)

--- a/test/adoc-mode-test.el
+++ b/test/adoc-mode-test.el
@@ -941,9 +941,24 @@ removed before TRANSFORM is evaluated.
         (set-buffer (get-buffer-create "adoc-test"))
         (insert "= document title\n"
                 "== chapter 1\n"
+                "[IMPORTANT]\n"
+                ".Important announcement\n"
+                "====\n"
+                "This should not be a title\n"
+                "====\n"
                 "=== sub chapter 1.1\n"
+                "[source,rust]\n"
+                "----\n"
+                "// here is a comment\n"
+                "----\n"
                 "chapter 2\n"
                 "----------\n"
+                "[latexmath#einstein]\n"
+                "++++\n"
+                "\begin{equation}\n"
+                "e = mc^{2}\n"
+                "\end{equation}\n"
+                "++++\n"
                 "sub chapter 2.1\n"
                 "~~~~~~~~~~~~~~\n")
         (should
@@ -952,9 +967,9 @@ removed before TRANSFORM is evaluated.
           (list
            (cons "document title" 1)
            (cons "chapter 1" 18)
-           (cons "sub chapter 1.1" 31)
-           (cons "chapter 2" 51)
-           (cons "sub chapter 2.1" 72)))))
+           (cons "sub chapter 1.1" 104)
+           (cons "chapter 2" 169)
+           (cons "sub chapter 2.1" 262)))))
     (kill-buffer "adoc-test")))
 
 ;; purpose


### PR DESCRIPTION
Fixes #17 by checking that 2-line titles have the same number of
under characters as the title text and doesn't look like the start
of an attribute block.

Unfortunately the length test can fail for multibyte text, and I don't
know a good solution to this in elisp.

Also check when (adoc-title-descriptor) returns nil, which it will at
times when the regexes match but more stringent tests fail, a nil list
will be inserted into the imenu list, which it doesn't like much, so
this condition is checked for as well.

Note the regex itself was not modified because it is used sometimes to
find titles with the wrong underline length, as noted in the comment
before these changes.