### PR TITLE
Add section about face customization to README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -83,6 +83,8 @@ or if you're into use-package
 
 == Configuration
 
+=== General
+
 * According to an old AsciiDoc manual, `.txt` is the standard file extension of
   AsciiDoc files. Add the following to your initialization file to open all
   `.txt` files with adoc-mode as major mode automatically: `(add-to-list
@@ -94,6 +96,40 @@ or if you're into use-package
   files you liked to have normal text with a variable pitch face,
   `buffer-face-mode` is for you: `(add-hook 'adoc-mode-hook (lambda()
   (buffer-face-mode t)))`
+
+=== Customization
+
+It is possible to customize the way `adoc-mode` renders different text
+elements (faces) like section titles, text or punctuation styles. For
+example, if you would like a level 1 section title to have a different
+text color or height you can achieve this by using standard Emacs
+functionality.
+
+First of all, list all available faces by running 
+
+kbd:[M-x] `list-faces-display`
+
+and searching for lines with the `adoc-` prefix.
+
+Alternatively, you can get information about the face under point by calling 
+
+kbd:[M-x] `describe-face`
+
+One possible solution to change the look of a face is to use the
+built-in `use-package` feature `:custom-face`.
+
+Example
+
+[source,emacs-lisp]
+----
+(use-package adoc-mode
+  :ensure t
+  :custom-face
+  (adoc-title-0-face ((t (:height 1.0 :weight bold)))))
+----
+
+Of course, this is only one way to do it. Emacs has a few ways to
+customize faces. Simply, pick the one you prefer.
 
 === Coming features
 


### PR DESCRIPTION
The README.adoc now contains a small section about face customization. This helps users to tailor the mode to individual preferences and needs.

Specifically, added two new level 3 sections to further structure the Configuration section. The first one (General) contains the old text and the new one (Customization) contains the newly added content.

The text contains some context, basic explanation and an easy example that users can copy/paste to their own configs.

Background: Users that don't have much experience in customizing Emacs and, maybe, expect config variables are not aware of the functionality and possibilities. This small section helps users to get started quickly by customizing adoc-mode to their needs. For example, I was not a big fan of those big section titles and wanted to make them smaller. 

-----------------

Before submitting a PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines](../blob/master/CONTRIBUTING.md)
- [ ] You've added tests (if possible) to cover your change(s)
- [ ] All tests are passing ([`eldev test`](https://github.com/doublep/eldev))
- [ ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!
