### PR TITLE
Fixes #33: Noticeable lag when typing in larger code blocks

### DIFF
--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -253,7 +253,7 @@ are fontified natively regardless of their size."
   :type '(choice :tag "Fontify code blocks " :format "\n%{%t%}: %[Size%] %v"
                  (integer :tag "limited to")
                  (boolean :tag "unlimited"))
-  :safe '(lambda (x) (or (booleanp x) (numberp x)))
+  :safe #'(lambda (x) (or (booleanp x) (numberp x)))
   :package-version '(adoc-mode . "0.8.0"))
 
 ;; This is based on `org-src-lang-modes' from org-src.el
@@ -1725,7 +1725,7 @@ Concerning TYPE, LEVEL and SUB-TYPE see `adoc-re-llisti'."
   (list
    ;; see also regexp of forced line break, which is similar. it is not directly
    ;; obvious from asciidoc sourcecode what the exact rules are.
-   '(lambda (end) (adoc-kwf-std end "^\\(\\+\\)[ \t]*$" '(1)))
+   #'(lambda (end) (adoc-kwf-std end "^\\(\\+\\)[ \t]*$" '(1)))
    '(1 '(face adoc-meta-face adoc-reserved block-del) t)))
 
 (defun adoc-kw-delimited-block (del &optional text-face inhibit-text-reserved)
@@ -2353,7 +2353,7 @@ Use this function as matching function MATCHER in `font-lock-keywords'."
 
    ;; --- general attribute list block element
    ;; ^\[(?P<attrlist>.*)\]$
-   (list '(lambda (end) (adoc-kwf-std end "^\\(\\[\\(.*\\)\\]\\)[ \t]*$" '(0)))
+   (list #'(lambda (end) (adoc-kwf-std end "^\\(\\[\\(.*\\)\\]\\)[ \t]*$" '(0)))
          '(1 '(face adoc-meta-face adoc-reserved block-del))
          '(2 '(face adoc-meta-face adoc-attribute-list t)))
 

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -2119,6 +2119,8 @@ Use this function as matching function MATCHER in `font-lock-keywords'."
             ;; Set background for block as well as opening and closing lines.
             (font-lock-append-text-property
              start-src end-src+nl 'face 'adoc-native-code-face)
+            (add-text-properties
+             start-src end-src+nl '(font-lock-fontified t font-lock-multiline t))
             )))
       t)))
 


### PR DESCRIPTION
Put text property font-lock-fontified on fontified source blocks.

