### PR TITLE
Src block/33font lock fontified missing

### DIFF
--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -1561,7 +1561,9 @@ Subgroups of returned regexp:
 Like `re-search-forward' with the same arguments
 REGEXP, BOUND, NOERROR and COUNT.
 If a match for REGEXP is found where the text property
-`adoc-code-block' is non-nil continue the search."
+`adoc-code-block' is non-nil continue the search.
+This speeds up the search and avoids the application of
+adoc-syntax to code blocks."
   (let (ret)
     (while (and
             (setq ret (re-search-forward regexp bound noerror count))

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -1577,9 +1577,8 @@ MUST-FREE-GROUPS a list of regexp group numbers which may not
 match text that has an adoc-reserved text-property with a non-nil
 value. Likewise, groups in NO-BLOCK-DEL-GROUPS may not contain
 text having adoc-reserved set to symbol `block-del'."
-  (let ((found t) (prevented t) saved-point)
+  (let ((found t) (prevented t))
     (while (and found prevented (<= (point) end) (not (eobp)))
-      (setq saved-point (point))
       (setq found (adoc-kwf-search regexp end t))
       (setq prevented
             (and found
@@ -1597,7 +1596,7 @@ text having adoc-reserved set to symbol `block-del'."
                                                      'adoc-reserved 'block-del)))
                            no-block-del-groups))))
       (when (and found prevented (<= (point) end))
-        (goto-char (1+ saved-point))))
+        (goto-char (1+ (match-beginning 0)))))
     (and found (not prevented))))
 
 (defun adoc-kwf-attribute-list (end)

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -2302,6 +2302,7 @@ Use this function as matching function MATCHER in `font-lock-keywords'."
    ;; ------------------------------
    (adoc-kw-delimited-block 0 adoc-comment-face)   ; comment
    (adoc-kw-delimited-block 1 adoc-passthrough-face) ; passthrough
+   (adoc-kw-delimited-block 2 adoc-code-face) ; listing
    (adoc-kw-delimited-block 3 adoc-verbatim-face) ; literal
    (adoc-kw-delimited-block 4 nil t) ; quote
    (adoc-kw-delimited-block 5 nil t) ; example

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -1902,10 +1902,8 @@ meta characters."
     ;; matcher function
     (lambda (end)
       (let (found)
-        (while (and (setq found
-                          (adoc-kwf-search ,regexp end t))
+        (while (and (setq found (adoc-kwf-search ,regexp end t))
                     (text-property-not-all (match-beginning 1) (match-end 1) 'adoc-reserved nil))
-          (setq found nil)
           (goto-char (+ (match-beginning 0) 1)))
         (when (and found adoc-insert-replacement ,replacement)
           (let* ((s (cond

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -1901,18 +1901,13 @@ meta characters."
   `(list
     ;; matcher function
     (lambda (end)
-      (let ((found t) (prevented t) saved-point)
-        (while (and found prevented)
-          (setq saved-point (point))
-          (setq found
-                (adoc-kwf-search ,regexp end t))
-          (setq prevented ; prevented is only meaningful wenn found is non-nil
-                (or
-                 (not found) ; the following is only needed when found
-                 (text-property-not-all (match-beginning 1) (match-end 1) 'adoc-reserved nil)))
-          (when (and found prevented)
-            (goto-char (+ saved-point 1))))
-        (when (and found (not prevented) adoc-insert-replacement ,replacement)
+      (let (found)
+        (while (and (setq found
+                          (adoc-kwf-search ,regexp end t))
+                    (text-property-not-all (match-beginning 1) (match-end 1) 'adoc-reserved nil))
+          (setq found nil)
+          (goto-char (+ (match-beginning 0) 1)))
+        (when (and found adoc-insert-replacement ,replacement)
           (let* ((s (cond
                      ((stringp ,replacement)
                       ,replacement)
@@ -1924,7 +1919,7 @@ meta characters."
             (setq adoc-replacement-failed (not o))
             (unless adoc-replacement-failed
               (overlay-put o 'after-string s))))
-        (and found (not prevented))))
+        found))
 
     ;; highlighers
     ;; TODO: replacement instead warining face if resolver is not given

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -253,7 +253,7 @@ are fontified natively regardless of their size."
   :type '(choice :tag "Fontify code blocks " :format "\n%{%t%}: %[Size%] %v"
                  (integer :tag "limited to")
                  (boolean :tag "unlimited"))
-  :safe '(lambda (x) (or (booleanp x) (numberp x)))
+  :safe #'(lambda (x) (or (booleanp x) (numberp x)))
   :package-version '(adoc-mode . "0.8.0"))
 
 ;; This is based on `org-src-lang-modes' from org-src.el
@@ -1725,7 +1725,7 @@ Concerning TYPE, LEVEL and SUB-TYPE see `adoc-re-llisti'."
   (list
    ;; see also regexp of forced line break, which is similar. it is not directly
    ;; obvious from asciidoc sourcecode what the exact rules are.
-   '(lambda (end) (adoc-kwf-std end "^\\(\\+\\)[ \t]*$" '(1)))
+   #'(lambda (end) (adoc-kwf-std end "^\\(\\+\\)[ \t]*$" '(1)))
    '(1 '(face adoc-meta-face adoc-reserved block-del) t)))
 
 (defun adoc-kw-delimited-block (del &optional text-face inhibit-text-reserved)
@@ -2119,6 +2119,8 @@ Use this function as matching function MATCHER in `font-lock-keywords'."
             ;; Set background for block as well as opening and closing lines.
             (font-lock-append-text-property
              start-src end-src+nl 'face 'adoc-native-code-face)
+            (add-text-properties
+             start-src end-src+nl '(font-lock-fontified t font-lock-multiline t))
             )))
       t)))
 
@@ -2351,7 +2353,7 @@ Use this function as matching function MATCHER in `font-lock-keywords'."
 
    ;; --- general attribute list block element
    ;; ^\[(?P<attrlist>.*)\]$
-   (list '(lambda (end) (adoc-kwf-std end "^\\(\\[\\(.*\\)\\]\\)[ \t]*$" '(0)))
+   (list #'(lambda (end) (adoc-kwf-std end "^\\(\\[\\(.*\\)\\]\\)[ \t]*$" '(0)))
          '(1 '(face adoc-meta-face adoc-reserved block-del))
          '(2 '(face adoc-meta-face adoc-attribute-list t)))
 

--- a/test/adoc-mode-test.el
+++ b/test/adoc-mode-test.el
@@ -1026,6 +1026,23 @@ Don't use it for anything real.")
            (cons "sub chapter 2.1" 262)))))
     (kill-buffer "adoc-test")))
 
+(ert-deftest adoctest-adoc-kw-replacement ()
+  (unwind-protect
+      (progn
+	(set-buffer (get-buffer-create "adoc-test"))
+	(erase-buffer)
+	(adoc-mode)
+	(let ((adoc-insert-replacement t))
+	  (adoc-calc)
+	  (insert "(C)")
+	  (font-lock-flush)
+	  (font-lock-ensure)
+	  (should (string-equal (overlay-get (car (overlays-in (point) (point-max))) 'after-string) "©"))
+	  )
+	)
+    (adoc-calc)
+    (kill-buffer "adoc-test")))
+
 ;; purpose
 ;; - ensure that the latest version, i.e. the one currently in buffer(s), of
 ;;   adoc-mode and adoc-mode-test is used for the test


### PR DESCRIPTION
- Introduce `adoc-kwf-search` that skips code blocks
- If a match is prevented in `adoc-kwf-std`, re-start search at the match string -- not at last start + 1 (this speeds up font-locking)
- re-structure `adoc-kw-replacement` such that it has the same speed-up as `adoc-kwf-std` and the code for the search operation is simplified
- add an ert test for `adoc-kw-replacement`