### PR TITLE
Fixes #39. Spaces and source-language name for language attribute

### DIFF
--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -2040,7 +2040,7 @@ START-SRC and END-SRC delimit the actual source code."
             (outer-brackets-and-delimiter (&rest stuff)
                                           (format "^\\[%s\\]\n\\(?2:----+\\)\n"
                                                   (apply #'concat stuff)))
-            (lang () ",\\(?1:[^],]+\\)")
+            (lang () ",[\t ]*\\(source-language[\t ]*=[\t ]*\\)?\\(?1:[^],]+\\)")
             (optional-other-args () "\\(?:,[^]]+\\)?"))
     (outer-brackets-and-delimiter
      (rx-or

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -2040,7 +2040,7 @@ START-SRC and END-SRC delimit the actual source code."
             (outer-brackets-and-delimiter (&rest stuff)
                                           ;; Listing blocks (delimiter ----) and literal blocks (delimiter ....) can have `source`-style:
                                           ;; https://docs.asciidoctor.org/asciidoc/latest/blocks/delimited/#summary-of-structural-containers
-                                          (format "^\\[%s\\]\s*\n\\(?2:\\(----+\\|\\.\\{4,\\}\\)\\)\n"
+                                          (format "^\\[%s\\]\\s-*\n\\(?2:\\(----+\\|\\.\\{4,\\}\\)\\)\n"
                                                   (apply #'concat stuff)))
             ;; The language attribute is positional only (2nd slot).
             ;; It gets its default value from the document attribute `source-language`.

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -2040,7 +2040,11 @@ START-SRC and END-SRC delimit the actual source code."
             (outer-brackets-and-delimiter (&rest stuff)
                                           (format "^\\[%s\\]\n\\(?2:----+\\)\n"
                                                   (apply #'concat stuff)))
-            (lang () ",[\t ]*\\(source-language[\t ]*=[\t ]*\\)?\\(?1:[^],]+\\)")
+            ;; The language attribute is positional only (2nd slot).
+            ;; It gets its default value from the document attribute `source-language`.
+            ;; The leading space between the comma and the 2nd attribute is ignored.
+            ;; See https://docs.asciidoctor.org/asciidoc/latest/attributes/element-attributes/#attribute-list.
+            (lang () ",[\t ]*\\(?1:[^],]+\\)")
             (optional-other-args () "\\(?:,[^]]+\\)?"))
     (outer-brackets-and-delimiter
      (rx-or

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -2038,9 +2038,9 @@ START-SRC and END-SRC delimit the actual source code."
   (cl-flet ((rx-or (first second) (format "\\(?:%s\\|%s\\)" first second))
             (rx-optional (stuff) (format "\\(?:%s\\)?" stuff))
             (outer-brackets-and-delimiter (&rest stuff)
-                                          ;; Listing blocks (delimiter ----) and literal blocks (delimiter ....) can have `source`-style:
+                                          ;; Listing blocks (delimiter ----), open blocks (delimiter --) and literal blocks (delimiter ....) can have `source`-style:
                                           ;; https://docs.asciidoctor.org/asciidoc/latest/blocks/delimited/#summary-of-structural-containers
-                                          (format "^\\[%s\\]\\s-*\n\\(?2:\\(----+\\|\\.\\{4,\\}\\)\\)\n"
+                                          (format "^\\[%s\\]\\s-*\n\\(?2:\\(--\\(?:--+\\)?\\|\\.\\{4,\\}\\)\\)\n"
                                                   (apply #'concat stuff)))
             ;; The language attribute is positional only (2nd slot).
             ;; It gets its default value from the document attribute `source-language`.

--- a/test/adoc-mode-test.el
+++ b/test/adoc-mode-test.el
@@ -352,6 +352,13 @@ Don't use it for anything real.")
        "\n" '(adoc-meta-face adoc-native-code-face)
        "----" 'adoc-meta-face
        "\n" nil
+       ;; Code block as OPEN BLOCK
+       "\n" nil
+       "[source,adoctest-lang]\n--\n" 'adoc-meta-face
+       source-code
+       "\n" '(adoc-meta-face adoc-native-code-face)
+       "--" 'adoc-meta-face
+       "\n" nil
        ;; Code block as Literal block
        "[source,adoctest-lang]\n....\n" 'adoc-meta-face
        source-code


### PR DESCRIPTION
The [asciidoctor manual](https://docs.asciidoctor.org/asciidoc/latest/attributes/positional-and-named-attributes/#attribute-list-parsing) accepts spaces at the beginning of the language attribute of code blocks. Furthermore, the language attribute can also be a named attribute `source-language`.

So

    [source,emacs-lisp]
    ----
    	(message "Hello world")
    ----

is the same as

    [source, emacs-lisp]
    ----
    	(message "Hello world")
    ----

and as

    [source, source-language = emacs-lisp]
    ----
    	(message "Hello world")
    ----

Only the first version is fontified as `emacs-lisp` in `origin/master` at commit `b0702bdeb8d799720661766936c36ec3b454c609`.

