### PR TITLE
[Fix #41] unconstrained typewriter

### DIFF
--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -2409,6 +2409,7 @@ Use this function as matching function MATCHER in `font-lock-keywords'."
    ;; AsciiDoc Manual: constitutes an inline literal passthrough. The enclosed
    ;; text is rendered in a monospaced font and is only subject to special
    ;; character substitution.
+   (adoc-kw-quote 'adoc-unconstrained "``" adoc-typewriter-face nil nil t)     ;1)
    (adoc-kw-quote 'adoc-constrained "`" adoc-typewriter-face nil nil t)     ;1)
    ;; AsciiDoc Manual: The triple-plus passthrough is functionally identical to
    ;; the pass macro but you don’t have to escape ] characters and you can

--- a/test/adoc-mode-test.el
+++ b/test/adoc-mode-test.el
@@ -583,6 +583,7 @@ Don't use it for anything real.")
   (adoctest-faces "test-quotes-simple"
                   ;; note that in unconstraned quotes cases " ipsum " has spaces around, in
                   ;; constrained quotes case it doesn't
+                  "Lorem " nil "``" adoc-meta-hide-face "ip" '(adoc-typewriter-face adoc-verbatim-face) "``" adoc-meta-hide-face "sum dolor\n" nil
                   "Lorem " nil "`" adoc-meta-hide-face "ipsum" '(adoc-typewriter-face adoc-verbatim-face) "`" adoc-meta-hide-face " dolor\n" nil
                   "Lorem " nil "+++" adoc-meta-hide-face " ipsum " '(adoc-typewriter-face adoc-verbatim-face) "+++" adoc-meta-hide-face " dolor\n" nil
                   "Lorem " nil "$$" adoc-meta-hide-face " ipsum " '(adoc-typewriter-face adoc-verbatim-face) "$$" adoc-meta-hide-face " dolor\n" nil


### PR DESCRIPTION
Add proper support for unconstrained typewriter formatting.
All backquotes around `ip` in the following example will be formatted with `adoc-meta-hide-face` and the `ip` itself will be formatted with `(adoc-typewriter-face adoc-verbatim-face)`.
```
Lorem ``ip``sum
```
