### PR TITLE
#44 Separate one-line header from next text block by paragraph-separate

### DIFF
--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -1487,7 +1487,10 @@ Subgroups of returned regexp:
    "--"
    "\\)"
    "[ \t]*$"
-   ))
+
+   ;; one line titles and block titles (https://docs.asciidoctor.org/asciidoc/latest/blocks/add-title/#block-title-syntax)
+   "\\|"
+   "[=.].*$"))
 
 ;; TODO: use same regexps as for font lock
 (defun adoc-re-paragraph-start ()
@@ -1512,10 +1515,7 @@ Subgroups of returned regexp:
    ;; table rows
    "\\|"
    "|"
-
-   ;; one line titles
-   "\\|"
-   "[=.].*$"))
+))
 
 (defun adoc-re-aor(e1 e2)
   "all or: Returns a regex matching \(e1\|e2\|e1e2\)? "

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -1991,18 +1991,12 @@ LANG is a string, and the returned major mode is a symbol."
          (intern (concat lang "-mode"))
          (intern (concat (downcase lang) "-mode")))))
 
-(defun adoc-map-intervals (fun property &optional beg end object)
-  "Apply FUN to all intervals of PROPERTY in OBJECT in the region from BEG to END."
-  (unless object (setq object (current-buffer)))
-  (unless beg (setq beg (point-min)))
-  (unless end (setq end (point-max)))
-  (let (end-interval)
-    (while
-	(progn
-	  (setq end-interval (next-single-property-change beg property object end))
-	  (funcall fun beg end-interval)
-	  (setq beg end-interval)
-	  (null (= end-interval end))))))
+(defmacro adoc-cond-let (cond binding &rest body)
+  "Let-bind BINDING when COND is fulfilled at compile-time.
+Execute BODY like `progn'."
+  (declare (debug (form (&rest (symbolp form)) body)) (indent 2))
+  `(let ,(when (eval cond) binding)
+     ,@body))
 
 ;; Based on `org-src-font-lock-fontify-block' from org-src.el.
 (defun adoc-fontify-code-block-natively (lang start-block end-block start-src end-src)
@@ -2031,14 +2025,15 @@ START-SRC and END-SRC delimit the actual source code."
             (insert string))
           (unless (eq major-mode lang-mode) (funcall lang-mode))
           (font-lock-ensure)
-          (adoc-map-intervals
-           (lambda (pos next)
-             (let ((val (get-text-property pos 'face)))
-               (when val
-                 (put-text-property
-                  (+ start-src (1- pos)) (1- (+ start-src next)) 'face
-                  val adoc-buffer))))
-           'face))
+          (adoc-cond-let (version< emacs-version "30.0") (int)
+            (cl-loop for int being the intervals property 'face
+                     for pos = (car int)
+                     for next = (cdr int)
+                     for val = (get-text-property pos 'face)
+                     when val do
+                     (put-text-property
+                      (+ start-src (1- pos)) (1- (+ start-src next)) 'face
+                      val adoc-buffer))))
         (add-text-properties start-block start-src '(face adoc-meta-face))
         (add-text-properties end-src end-block '(face adoc-meta-face))
         (add-text-properties

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -1991,12 +1991,18 @@ LANG is a string, and the returned major mode is a symbol."
          (intern (concat lang "-mode"))
          (intern (concat (downcase lang) "-mode")))))
 
-(defmacro adoc-cond-let (cond binding &rest body)
-  "Let-bind BINDING when COND is fulfilled at compile-time.
-Execute BODY like `progn'."
-  (declare (debug (form (&rest (symbolp form)) body)) (indent 2))
-  `(let ,(when (eval cond) binding)
-     ,@body))
+(defun adoc-map-intervals (fun property &optional beg end object)
+  "Apply FUN to all intervals of PROPERTY in OBJECT in the region from BEG to END."
+  (unless object (setq object (current-buffer)))
+  (unless beg (setq beg (point-min)))
+  (unless end (setq end (point-max)))
+  (let (end-interval)
+    (while
+	(progn
+	  (setq end-interval (next-single-property-change beg property object end))
+	  (funcall fun beg end-interval)
+	  (setq beg end-interval)
+	  (null (= end-interval end))))))
 
 ;; Based on `org-src-font-lock-fontify-block' from org-src.el.
 (defun adoc-fontify-code-block-natively (lang start-block end-block start-src end-src)
@@ -2025,15 +2031,14 @@ START-SRC and END-SRC delimit the actual source code."
             (insert string))
           (unless (eq major-mode lang-mode) (funcall lang-mode))
           (font-lock-ensure)
-          (adoc-cond-let (version< emacs-version "30.0") (int)
-            (cl-loop for int being the intervals property 'face
-                     for pos = (car int)
-                     for next = (cdr int)
-                     for val = (get-text-property pos 'face)
-                     when val do
-                     (put-text-property
-                      (+ start-src (1- pos)) (1- (+ start-src next)) 'face
-                      val adoc-buffer))))
+          (adoc-map-intervals
+           (lambda (pos next)
+             (let ((val (get-text-property pos 'face)))
+               (when val
+                 (put-text-property
+                  (+ start-src (1- pos)) (1- (+ start-src next)) 'face
+                  val adoc-buffer))))
+           'face))
         (add-text-properties start-block start-src '(face adoc-meta-face))
         (add-text-properties end-src end-block '(face adoc-meta-face))
         (add-text-properties

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -2005,7 +2005,7 @@ START-SRC and END-SRC delimit the actual source code."
     (when (fboundp lang-mode)
       (let ((string (buffer-substring-no-properties start-src end-src))
             (modified (buffer-modified-p))
-            (adoc-buffer (current-buffer)) int)
+            (adoc-buffer (current-buffer)))
         (remove-text-properties start-block end-block '(face nil adoc-code-block nil font-lock-fontified nil font-lock-multiline nil))
         (with-current-buffer
             (get-buffer-create
@@ -2018,7 +2018,8 @@ START-SRC and END-SRC delimit the actual source code."
             (insert string))
           (unless (eq major-mode lang-mode) (funcall lang-mode))
           (font-lock-ensure)
-          (cl-loop for int being the intervals property 'face
+          (cl-loop for int = nil
+                   for int being the intervals property 'face
                    for pos = (car int)
                    for next = (cdr int)
                    for val = (get-text-property pos 'face)

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -1992,8 +1992,7 @@ LANG is a string, and the returned major mode is a symbol."
          (intern (concat (downcase lang) "-mode")))))
 
 (defun adoc-map-intervals (fun property &optional beg end object)
-  "Apply FUN to all intervals of PROPERTY in OBJECT in the region from BEG to END.
-FUN is called with two arguments: the beginning and the end of the interval."
+  "Apply FUN to all intervals of PROPERTY in OBJECT in the region from BEG to END."
   (unless object (setq object (current-buffer)))
   (unless beg (setq beg (point-min)))
   (unless end (setq end (point-max)))

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -1992,7 +1992,8 @@ LANG is a string, and the returned major mode is a symbol."
          (intern (concat (downcase lang) "-mode")))))
 
 (defun adoc-map-intervals (fun property &optional beg end object)
-  "Apply FUN to all intervals of PROPERTY in OBJECT in the region from BEG to END."
+  "Apply FUN to all intervals of PROPERTY in OBJECT in the region from BEG to END.
+FUN is called with two arguments: the beginning and the end of the interval."
   (unless object (setq object (current-buffer)))
   (unless beg (setq beg (point-min)))
   (unless end (setq end (point-max)))


### PR DESCRIPTION
Move one-line header regexp from `adoc-re-paragraph-start` to `adoc-re-paragraph-separate`.
`paragraph-separate` is merged into `paragraph-start` anyway.

This should fix #44.
