### PR TITLE
Work/47display images

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,6 +35,7 @@ Here are some of the main features of `adoc-mode`:
 
 - sophisticated highlighting
 - native fontification of code blocks
+- toggle between the display of image links and the display of the corresponding images
 - promote / demote title
 - toggle title type between one line title and two line title
 - adjust underline length of a two line title to match title text's length
@@ -44,9 +45,11 @@ Here are some of the main features of `adoc-mode`:
 === Demo
 
 The highlighting emphasizes on how the output will look like. _All_
-characters are visible, however meta characters are displayed in a faint way.
+characters are visible, however meta characters are displayed in a
+faint way.  An exception are image links.  You can toggle between
+the display of the link text and the linked image.
 
-image:images/adoc-mode.png[alt=screenshot]
+image::images/adoc-mode.png[alt=screenshot]
 
 == Installation
 
@@ -111,6 +114,16 @@ This can be tweaked by several configuration options:
 * All programming languages `XYZ` that have an Emacs major mode `XYZ-mode` and use `font-lock` are automatically supported. Some other languages not fitting into that name scheme are supported through the alist `adoc-code-lang-modes`. You can add your own languages and modes there if they work based on `font-lock` and are not automatically supported.
 * The fall-back language mode is `prog-mode` without any fontification. You can set your own default by `adoc-fontify-code-block-default-mode`.
 
+=== Display of Image Links
+
+You can toggle between the display of image links and the display of the corresponding images with the menu item _AsciiDoc → Toggle display of images_. Each image link and each image has a context menu where you can display and remove the image preview at point.
+
+Images in an AsciiDoc file are shown as preview when you open it by default. You can avoid that by deactivating the option `adoc-display-remote-images`.
+
+The maximal size for the preview of images can be set by `adoc-max-image-size`.
+
+An image link can also be given as url to a remote image. The display of remote images is switched off by default. You can activate it by the option `adoc-display-remote-images`.
+Thereby, images are only downloaded if the protocol of the url matches one of those in the list `adoc-remote-image-protocols`. This list can be customized. By default, it only contains the entry `https`.
 === Syntax Highlighting Customization
 
 It is possible to customize the way `adoc-mode` renders different text

--- a/README.adoc
+++ b/README.adoc
@@ -51,6 +51,34 @@ the display of the link text and the linked image.
 
 image::images/adoc-mode.png[alt=screenshot]
 
+== Usage
+
+Adoc-mode is designed for intuitive use. Most features are available
+from the _AsciiDoc_ menu in the menu bar.
+
+This section only describes some not so obvious features.
+
+=== Image Preview
+If you click kbd:[mouse-3] on an image link like
+`image⁣:path/to/image[]` the _Image_ context menu pops up.
+
+This context menu allows you to generate or remove the preview for
+the linked image.
+
+The menu item _AsciiDoc → Toggle display of images_ runs the command
+`adoc-toggle-images`. It removes all image previews from the buffer
+if there are any. If there are no image previews in the buffer it
+generates them for all image links.
+
+This may be confusing if all image previews are outside the visible
+region of the buffer. In this case, you might expect `adoc-toggle-images`
+to generate the previews for the image links in the visible area on
+the first run. But it does not, since it first removes all the
+previews, even if you have not seen them.
+
+Just run `adoc-toggle-images` again if it does not what you expect on
+the first run.
+
 == Installation
 
 `adoc-mode` is available on the community-maintained
@@ -114,11 +142,10 @@ This can be tweaked by several configuration options:
 * All programming languages `XYZ` that have an Emacs major mode `XYZ-mode` and use `font-lock` are automatically supported. Some other languages not fitting into that name scheme are supported through the alist `adoc-code-lang-modes`. You can add your own languages and modes there if they work based on `font-lock` and are not automatically supported.
 * The fall-back language mode is `prog-mode` without any fontification. You can set your own default by `adoc-fontify-code-block-default-mode`.
 
-=== Display of Image Links
+=== Display of Image Previews
 
-You can toggle between the display of image links and the display of the corresponding images with the menu item _AsciiDoc → Toggle display of images_. Each image link and each image has a context menu where you can display and remove the image preview at point.
-
-Images in an AsciiDoc file are shown as preview when you open it by default. You can avoid that by deactivating the option `adoc-display-remote-images`.
+Images are shown as preview by default when you open an AsciiDoc file.
+You can avoid this by deactivating the option `adoc-display-images`.
 
 The maximal size for the preview of images can be set by `adoc-max-image-size`.
 

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -44,10 +44,7 @@
 
 (require 'cl-lib)
 (require 'tempo)
-(eval-when-compile
-  (when (version< emacs-version "29.0") ;; when-let has moved from subr-x to subr
-    (require 'subr-x)
-    ))
+(require 'subr-x)
 
 (declare-function imagep "image.c")
 (declare-function image-flush "image.c")

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -320,8 +320,8 @@ requires Emacs to be built with ImageMagick support."
                 (choice (sexp :tag "Maximum height in pixels")
                         (const :tag "No maximum height" nil)))))
 
-(defcustom adoc-display-images-at-startup t
-  "Run `adoc-display-images' in `adoc-mode'."
+(defcustom adoc-display-images t
+  "Run `adoc-display-images' in function `adoc-mode'."
   :group 'adoc
   :package-version '(adoc-mode . "0.9.0")
   :type 'boolean)
@@ -3775,7 +3775,7 @@ Turning on Adoc mode runs the normal hook `adoc-mode-hook'."
   (when (boundp 'compilation-error-regexp-alist)
     (make-local-variable 'compilation-error-regexp-alist)
     (add-to-list 'compilation-error-regexp-alist 'asciidoc))
-  (when (and (display-graphic-p) adoc-display-images-at-startup)
+  (when (and (display-graphic-p) adoc-display-images)
     (adoc-display-images)))
 
 ;;;###autoload

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -328,7 +328,7 @@ requires Emacs to be built with ImageMagick support."
 (defcustom adoc-show-images-at-startup t
   "Run `adoc-display-images' in `adoc-mode'."
   :group 'adoc
-  :type 'booleanp)
+  :type 'boolean)
 
 
 ;;;; faces / font lock

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -46,6 +46,10 @@
 (require 'tempo)
 (require 'mouse)
 (require 'image)
+(eval-when-compile
+  (when (version< emacs-version "29.0") ;; when-let has moved from subr-x to subr
+    (require 'subr-x)
+    ))
 
 (defconst adoc-mode-version "0.8.0-snapshot"
   "adoc mode version number.

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -310,7 +310,7 @@ When nil, use the actual size.  Otherwise, use ImageMagick to
 resize larger images to be of the given maximum dimensions.  This
 requires Emacs to be built with ImageMagick support."
   :group 'adoc
-  :package-version '(markdown-mode . "0.8.0")
+  :package-version '(adoc-mode . "0.9.0")
   :type '(choice
           (const :tag "Use actual image width" nil)
           (cons (choice (sexp :tag "Maximum width in pixels")

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -51,6 +51,9 @@
     (require 'subr-x)
     ))
 
+(declare-function imagep "image.c")
+(declare-function image-flush "image.c")
+
 (defconst adoc-mode-version "0.8.0-snapshot"
   "adoc mode version number.
 

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -44,6 +44,8 @@
 
 (require 'cl-lib)
 (require 'tempo)
+(require 'mouse)
+(require 'image)
 
 (defconst adoc-mode-version "0.8.0-snapshot"
   "adoc mode version number.

--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -3770,7 +3770,7 @@ Turning on Adoc mode runs the normal hook `adoc-mode-hook'."
   (when (boundp 'compilation-error-regexp-alist)
     (make-local-variable 'compilation-error-regexp-alist)
     (add-to-list 'compilation-error-regexp-alist 'asciidoc))
-  (when adoc-show-images-at-startup
+  (when (and (display-graphic-p) adoc-show-images-at-startup)
     (adoc-display-images)))
 
 ;;;###autoload


### PR DESCRIPTION
Display images natively in adoc-mode (without the need of `texfrag-mode`).
The implementation is adopted from `markdown-mode`.

The display of images can be turned on via the corresponding AsciiDoc menu item.

The sub-menu `Image` is added to the context menu from `context-menu-mode`.
Currently, there is only the menu item "Generate preview at point" or "Remove preview at point" in there.
But, a menu item for an image editor can be added there.
