### PR TITLE
Fall back to general fontification of source blocks if lang attr is n…

### DIFF
--- a/adoc-mode.el
+++ b/adoc-mode.el
@@ -2109,9 +2109,10 @@ Group 2 contains the block delimiter.")
   "Search for next adoc-code block up to LAST.
 NOERROR is the same as for `search-forward'.
 
-Return the source block language and
+Return a string with the source block language and
 set match data if a source block is found.
-Otherwise return nil.
+If the source block is given without the language attribute return t.
+If no source block is found return nil.
 
 The overall match data begins at the
 header of the code block and ends at the end of the
@@ -2167,9 +2168,11 @@ Use this function as matching function MATCHER in `font-lock-keywords'."
                  (end-src (match-end 1))
                  (end-src+nl (if (eq (char-after end-src) ?\n) (1+ end-src) end-src))
                  (size (1+ (- end-src start-src))))
-            (if (if (numberp adoc-fontify-code-blocks-natively)
-                    (<= size adoc-fontify-code-blocks-natively)
-                  adoc-fontify-code-blocks-natively)
+            (if (and
+                 (if (numberp adoc-fontify-code-blocks-natively)
+                     (<= size adoc-fontify-code-blocks-natively)
+                   adoc-fontify-code-blocks-natively)
+                 (stringp lang))
                 (adoc-fontify-code-block-natively lang start-block end-block start-src end-src)
               (add-text-properties
                start-src

--- a/test/adoc-mode-test.el
+++ b/test/adoc-mode-test.el
@@ -349,26 +349,32 @@ Don't use it for anything real.")
        "\n" nil
        "[source,adoctest-lang]\n----\n" 'adoc-meta-face
        source-code
-       "\n" '(adoc-meta-face adoc-native-code-face)
+       "\n" 'adoc-native-code-face
+       "----" 'adoc-meta-face
+       "\n" nil
+       ;; Code blocks without language attribute
+       "[source]\n----\n" 'adoc-meta-face
+       (apply #'concat (cl-loop for str in source-code by #'cddr collect str)) '(adoc-verbatim-face adoc-code-face)
+       "\n" 'adoc-code-face
        "----" 'adoc-meta-face
        "\n" nil
        ;; Code block as OPEN BLOCK
        "\n" nil
        "[source,adoctest-lang]\n--\n" 'adoc-meta-face
        source-code
-       "\n" '(adoc-meta-face adoc-native-code-face)
+       "\n" 'adoc-native-code-face
        "--" 'adoc-meta-face
        "\n" nil
        ;; Code block as Literal block
        "[source,adoctest-lang]\n....\n" 'adoc-meta-face
        source-code
-       "\n" '(adoc-meta-face adoc-native-code-face)
+       "\n" 'adoc-native-code-face
        "...." 'adoc-meta-face
        "\n" nil
        ;; Test ignored spaces
        "[source,\t adoctest-lang]\t \n....\n" 'adoc-meta-face
        source-code
-       "\n" '(adoc-meta-face adoc-native-code-face)
+       "\n" 'adoc-native-code-face
        "...." 'adoc-meta-face
        "\n" nil
        ))))


### PR DESCRIPTION
Asciidoctor also fontifies code blocks without language attribute like:

[source]
----
general code block
----

Adapt `adoc-fontify-code-blocks` to that case.
